### PR TITLE
Cip68 structs encode & decode with field names, not serialization keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
         "test": "pnpm run test:pretty && pnpm run test:types && pnpm run test:suite",
         "test:pretty": "prettier . --check",
         "test:suite": "node --test",
-        "testing": "node --test --watch",
-        "testing:debug": "node --inspect-brk --test --watch",
-        "test:types": "pnpm run build:types"
+        "test:types": "pnpm run build:types",
+        "testing": "HL_TEST_TRACE=ok node --test --watch",
+        "testing:debug": "HL_TEST_TRACE=ok node --inspect-brk --test --watch"
     },
     "author": "Christian Schmitz",
     "license": "BSD-3-Clause",

--- a/src/cast/Cast.js
+++ b/src/cast/Cast.js
@@ -60,6 +60,21 @@ import {
  */
 
 /**
+ * @typedef {Object} SchemaToUplcContext
+ * @property {Record<string, TypeSchema>} defs - symbol table permitting recursive schema references
+ * @property {string} dataPath - provides developer-facing cues for any parsing errors, showing the deep field path of any error
+ * @property {boolean} [isInEnum] - a single-level indicator of being directly inside an enum (internal use)
+ */
+
+/**
+ * @typedef {Object} UplcToSchemaContext
+ * @property {Record<string, TypeSchema>} defs - symbol table permitting recursive schema references
+ * @property {string} dataPath - provides developer-facing cues for any parsing errors, showing the deep field path of any error
+ * @property {boolean} [isInEnum] - a single-level indicator of being directly inside an enum (internal use)
+ * @property {CastConfig} config - has isMainnet indicator
+ */
+
+/**
  * @template TStrict
  * @template TPermissive=TStrict
  */
@@ -87,10 +102,15 @@ export class Cast {
 
     /**
      * @param {UplcData} data
+     * @param {string} [dataPath] - can be used to indicate the kind or context of data-decoding
      * @returns {TStrict}
      */
-    fromUplcData(data) {
-        return uplcToSchema(this.schema, data, this.config)
+    fromUplcData(data, dataPath = "") {
+        return uplcToSchemaWithDataPath(this.schema, data, {
+            config: this.config,
+            dataPath,
+            defs: {}
+        })
     }
 
     /**
@@ -105,7 +125,10 @@ export class Cast {
      * @returns {UplcData}
      */
     toUplcData(x, dataPath = "") {
-        const t = schemaToUplcWithDataPath(this.schema, x, {}, dataPath)
+        const t = schemaToUplcWithDataPath(this.schema, x, {
+            defs: {},
+            dataPath
+        })
         t.rawData = x
         return t
     }
@@ -114,19 +137,18 @@ export class Cast {
 /**
  * @param {TypeSchema} schema
  * @param {any} x
- * @param {Record<string, TypeSchema>} defs
- * @param {string} dataPath
+ * @param {SchemaToUplcContext} context
  * @returns {UplcData}
  */
-function schemaToUplcWithDataPath(schema, x, defs = {}, dataPath = "") {
+function schemaToUplcWithDataPath(schema, x, context) {
     try {
-        const t = schemaToUplc(schema, x, defs, dataPath)
-        t.dataPath = dataPath
+        const t = schemaToUplc(schema, x, context)
+        t.dataPath = context.dataPath
         return t
     } catch (e) {
         if (!e.uplcDataPath) {
-            e.message = `${e.message}\n ... at ${dataPath}`
-            e.uplcDataPath = dataPath
+            e.message = `${e.message}\n ... at ${context.dataPath}`
+            e.uplcDataPath = context.dataPath
         }
         debugger
         throw e
@@ -136,21 +158,25 @@ function schemaToUplcWithDataPath(schema, x, defs = {}, dataPath = "") {
 /**
  * @param {TypeSchema} schema
  * @param {any} x
- * @param {Record<string, TypeSchema>} defs
- * @param {string} dataPath
+ * @param {SchemaToUplcContext} inputContextOnly
  * @returns {UplcData}
  */
-function schemaToUplc(schema, x, defs = {}, dataPath = "") {
+function schemaToUplc(schema, x, inputContextOnly) {
+    // const { +defs = {}, dataPath = "", isInEnum = false } = inputContext
+    // important: DON'T extend the inputContext for use in nested calls.
+    const { dataPath, isInEnum, defs } = inputContextOnly
+
+    // Only the defs can be passed down, and it's simpler syntactically
+    //   ... just use the defs directly in the nested calls.
+
     const kind = schema.kind
     switch (kind) {
         case "reference": {
             const def = expectSome(defs[schema.id])
-            return schemaToUplcWithDataPath(
-                def,
-                x,
+            return schemaToUplcWithDataPath(def, x, {
                 defs,
-                `${dataPath}::ref{${schema.id}}`
-            )
+                dataPath: `${dataPath}::ref{${schema.id}}`
+            })
         }
         case "internal": {
             const name = schema.name
@@ -228,12 +254,10 @@ function schemaToUplc(schema, x, defs = {}, dataPath = "") {
         case "list":
             return new ListData(
                 x.map((x, i) =>
-                    schemaToUplcWithDataPath(
-                        schema.itemType,
-                        x,
+                    schemaToUplcWithDataPath(schema.itemType, x, {
                         defs,
-                        `${dataPath}.list[${i}]`
-                    )
+                        dataPath: `${dataPath}.list[${i}]`
+                    })
                 )
             )
         case "map": {
@@ -244,42 +268,37 @@ function schemaToUplc(schema, x, defs = {}, dataPath = "") {
                       ? x
                       : Object.entries(x)
             return new MapData(
-                entries.map(([k, v]) => [
-                    schemaToUplcWithDataPath(
-                        schema.keyType,
-                        k,
-                        defs,
-                        `${dataPath}[mapKey '${k}']`
-                    ),
-                    schemaToUplcWithDataPath(
-                        schema.valueType,
-                        v,
-                        defs,
-                        `${dataPath}[map].${k}`
-                    )
-                ])
+                entries.map(([k, v], i) => {
+                    const displayKey = "string" == typeof k ? `'${k}'` : `@{i}`
+                    return [
+                        schemaToUplcWithDataPath(schema.keyType, k, {
+                            defs,
+                            dataPath: `${dataPath}[mapKey ${displayKey}]`
+                        }),
+                        schemaToUplcWithDataPath(schema.valueType, v, {
+                            defs,
+                            dataPath: `${dataPath}[mapVal ${displayKey}]`
+                        })
+                    ]
+                })
             )
         }
         case "tuple":
             return new ListData(
                 x.map((x, i) =>
-                    schemaToUplcWithDataPath(
-                        schema.itemTypes[i],
-                        x,
+                    schemaToUplcWithDataPath(schema.itemTypes[i], x, {
                         defs,
-                        `${dataPath}[tuple@${i}]`
-                    )
+                        dataPath: `${dataPath}[tuple@${i}]`
+                    })
                 )
             )
         case "option":
             return encodeOptionData(
                 x
-                    ? schemaToUplcWithDataPath(
-                          schema.someType,
-                          x,
+                    ? schemaToUplcWithDataPath(schema.someType, x, {
                           defs,
-                          `${dataPath}::Some`
-                      )
+                          dataPath: `${dataPath}::Some`
+                      })
                     : None
             )
         case "struct": {
@@ -290,58 +309,82 @@ function schemaToUplc(schema, x, defs = {}, dataPath = "") {
                     return schemaToUplcWithDataPath(
                         schema.fieldTypes[0].type,
                         x[singleFieldName],
-                        defs,
-                        `${dataPath}[sStruct.${singleFieldName}]`
+                        {
+                            defs,
+                            dataPath: `${dataPath}[sStruct.${singleFieldName}]`
+                        }
                     )
                 case "list":
                     return new ListData(
                         schema.fieldTypes.map(({ name, type }) =>
-                            schemaToUplcWithDataPath(
-                                type,
-                                x[name],
-                                {},
-                                `${dataPath}[fStruct].${name}`
-                            )
+                            schemaToUplcWithDataPath(type, x[name], {
+                                defs,
+                                dataPath: `${dataPath}[fStruct].${name}`
+                            })
                         )
                     )
                 case "map": {
                     // first make sure all fields are present
                     schema.fieldTypes.forEach((ft) => {
+                        // todo: ? allow Option[T] fields to be missing?
+
                         if (!(ft.name in x)) {
-                            throw new Error(`missing field ${ft.name}`)
+                            if (ft.encodingKey && ft.encodingKey in x) {
+                                const encodingInfo = ft.encodingKey
+                                    ? `incorrectly specified as encoding-key '${ft.encodingKey}')`
+                                    : ""
+                                throw new Error(
+                                    `field '${ft.name}' ${encodingInfo}`
+                                )
+                            }
+                            throw new Error(`missing field '${ft.name}'`)
                         }
                     })
 
-                    // respect order of entries
+                    // respect order of entries in provided data
+                    // todo: ? allow encoding-order to match schema-defined order instead ?
+                    // todo: ? allow the encoding to follow the encoding keys in sorted order?
                     /**
                      * @type {[UplcData, UplcData][]}
                      */
                     const pairs = []
 
-                    Object.entries(x).forEach(([key, value]) => {
+                    Object.entries(x).forEach(([fieldName, value]) => {
                         const ft = schema.fieldTypes.find(
-                            (ft) => ft.name == key
+                            (ft) => ft.name == fieldName
                         )
 
                         if (ft) {
-                            debugger
-                            // const rawKey = ft.key || ft.name
-                            const rawKey = ft.name
+                            const encodingKey = ft.encodingKey || ft.name
+                            const encodingInfo = ft.encodingKey
+                                ? `@'${ft.encodingKey}'`
+                                : ""
+                            // ?? encode field-name into the keyData??
+                            // xxxx  feels way wrong!
                             const keyData = new ByteArrayData(
-                                encodeUtf8(rawKey)
+                                encodeUtf8(encodingKey)
                             )
+
                             const valueData = schemaToUplcWithDataPath(
                                 ft.type,
                                 value,
-                                defs,
-                                `${dataPath}[mStruct][${key}]`
+                                {
+                                    defs,
+                                    dataPath: `${dataPath}[mStruct].${fieldName}${encodingInfo}`
+                                }
                             )
 
                             pairs.push([keyData, valueData])
                         }
                     })
 
-                    // wrapped in ConstrData
+                    // when this is a CIP-68 struct, this lets us be sensitive to the context of
+                    // "it already has a ConstrData wrapper", and avoid double-wrapping it.
+                    if (isInEnum) {
+                        return new MapData(pairs)
+                    }
+
+                    // otherwise, wrap in ConstrData
                     return new ConstrData(0, [new MapData(pairs)])
                 }
                 default:
@@ -364,34 +407,58 @@ function schemaToUplc(schema, x, defs = {}, dataPath = "") {
                 )
             }
 
+            // Gives the encoding of nested data a context to prevent a second ConstrData wrapper on the MapData
+            // ... only for the first field.
+            const fieldCount = schema.variantTypes[tag].fieldTypes.length
             return new ConstrData(
                 tag,
-                schema.variantTypes[tag].fieldTypes.map((f) =>
-                    schemaToUplcWithDataPath(
-                        f.type,
-                        variantFields[f.name],
+                schema.variantTypes[tag].fieldTypes.map((f, i) =>
+                    schemaToUplcWithDataPath(f.type, variantFields[f.name], {
                         defs,
-                        `${dataPath}[${schema.name}::${variantName}].${f.name}`
-                    )
+                        isInEnum: fieldCount <= 3 && i == 0,
+                        dataPath: `${dataPath}[${schema.name}::${variantName}].${f.name}`
+                    })
                 )
             )
         }
         case "variant":
             defs[schema.id] = schema
+            throw new Error(`unused?`)
 
-            return new ConstrData(
-                schema.tag,
-                schema.fieldTypes.map(({ name, type }) =>
-                    schemaToUplcWithDataPath(
-                        type,
-                        x[name],
-                        {},
-                        `${dataPath}.${name}`
-                    )
-                )
-            )
+        // return new ConstrData(
+        //     schema.tag,
+        //     schema.fieldTypes.map(({ name, type }) =>
+        //         schemaToUplcWithDataPath(type, x[name], {
+        //             defs,
+        //             isInEnum: true,
+        //             dataPath: `${dataPath}.${name}`
+        //         })
+        //     )
+        // )
         default:
             throw new Error(`unhandled schema kind '${kind}'`)
+    }
+}
+
+/**
+ * @param {TypeSchema} schema
+ * @param {UplcData} data
+ * @param {UplcToSchemaContext} context
+ * @returns {any}
+ */
+function uplcToSchemaWithDataPath(schema, data, context) {
+    try {
+        const t = uplcToSchema(schema, data, context)
+        return t
+    } catch (e) {
+        if (!e.uplcDataPath) {
+            e.message =
+                `decoding UPLC data: ${e.message}` +
+                (context.dataPath ? `\n ... at ${context.dataPath}` : "")
+            e.uplcDataPath = context.dataPath
+        }
+        debugger
+        throw e
     }
 }
 
@@ -399,12 +466,15 @@ function schemaToUplc(schema, x, defs = {}, dataPath = "") {
  * This should fail when deviating
  * @param {TypeSchema} schema
  * @param {UplcData} data
- * @param {CastConfig} config
- * @param {Record<string, TypeSchema>} defs
+ * @param {UplcToSchemaContext} inputContextOnly
  * @returns {any}
  */
-function uplcToSchema(schema, data, config, defs = {}) {
+function uplcToSchema(schema, data, inputContextOnly) {
     const kind = schema.kind
+    const { config, defs } = inputContextOnly
+    // Note: don't use the inputContext directly in nested calls.
+    const { dataPath, isInEnum, ...context } = inputContextOnly
+    //   use { ... context } augmented with the new dataPath and isInEnum (if applicable)
 
     switch (kind) {
         case "internal": {
@@ -482,24 +552,44 @@ function uplcToSchema(schema, data, config, defs = {}) {
             }
         }
         case "list":
-            return ListData.expect(data).items.map((x) =>
-                uplcToSchema(schema.itemType, x, config, defs)
+            return ListData.expect(data).items.map((x, i) =>
+                uplcToSchemaWithDataPath(schema.itemType, x, {
+                    ...context,
+                    dataPath: `${dataPath}[${i}]`
+                })
             )
         case "map":
             return new Map(
-                MapData.expect(data).items.map(([k, v]) => [
-                    uplcToSchema(schema.keyType, k, config, defs),
-                    uplcToSchema(schema.valueType, v, config, defs)
-                ])
+                MapData.expect(data).items.map(([k, v], i) => {
+                    const key = uplcToSchemaWithDataPath(schema.keyType, k, {
+                        ...context,
+                        dataPath: `${dataPath}[mapKey @${i}]`
+                    })
+                    const displayKey =
+                        "string" == typeof key ? `'${key}'` : `@{i}`
+                    return [
+                        key,
+                        uplcToSchemaWithDataPath(schema.valueType, v, {
+                            ...context,
+                            dataPath: `${dataPath}[mapVal ${displayKey}]`
+                        })
+                    ]
+                })
             )
         case "tuple":
             return ListData.expect(data).items.map((x, i) =>
-                uplcToSchema(schema.itemTypes[i], x, config, defs)
+                uplcToSchemaWithDataPath(schema.itemTypes[i], x, {
+                    ...context,
+                    dataPath: `${dataPath}[tuple@${i}]`
+                })
             )
         case "option": {
             const optionData = decodeOptionData(data)
             return optionData
-                ? uplcToSchema(schema.someType, optionData, config, defs)
+                ? uplcToSchemaWithDataPath(schema.someType, optionData, {
+                      ...context,
+                      dataPath: `${dataPath}::Some`
+                  })
                 : None
         }
         case "struct": {
@@ -507,11 +597,10 @@ function uplcToSchema(schema, data, config, defs = {}) {
             switch (schema.format) {
                 case "singleton":
                     return {
-                        [schema.fieldTypes[0].name]: uplcToSchema(
+                        [schema.fieldTypes[0].name]: uplcToSchemaWithDataPath(
                             schema.fieldTypes[0].type,
                             data,
-                            config,
-                            defs
+                            { ...context, dataPath: `${dataPath}[sStruct]` }
                         )
                     }
                 case "list": {
@@ -524,53 +613,77 @@ function uplcToSchema(schema, data, config, defs = {}) {
                     }
 
                     return Object.fromEntries(
-                        fields.map((field, i) => [
-                            schema.fieldTypes[i].name,
-                            uplcToSchema(
-                                schema.fieldTypes[i].type,
-                                field,
-                                config,
-                                defs
-                            )
-                        ])
+                        fields.map((field, i) => {
+                            // "field-list" structs don't have encoding-keys, by definition.
+                            const { name, type } = schema.fieldTypes[i]
+                            return [
+                                name,
+                                uplcToSchemaWithDataPath(type, field, {
+                                    ...context,
+                                    dataPath: `${dataPath}[fStruct].${name}`
+                                })
+                            ]
+                        })
                     )
                 }
                 case "map": {
-                    // wrapped in ConstrData
-                    const entries = MapData.expect(
-                        ConstrData.expect(data).fields[0]
-                    ).items
+                    // might be wrapped in ConstrData
+                    const encodedEntries = isInEnum
+                        ? MapData.expect(data).items
+                        : MapData.expect(ConstrData.expect(data).fields[0])
+                              .items
 
-                    if (entries.length != schema.fieldTypes.length) {
+                    if (encodedEntries.length != schema.fieldTypes.length) {
                         throw new Error(
-                            `expected ${schema.fieldTypes.length} fields in struct, got ${entries.length} fields`
+                            `expected ${schema.fieldTypes.length} fields in struct, got ${encodedEntries.length} fields`
                         )
                     }
 
+                    /**
+                     * @param {string} targetName
+                     * @returns {number}
+                     */
+                    function findEncodedFieldIndex(targetName) {
+                        return encodedEntries.findIndex(([key, _]) => {
+                            return (
+                                targetName ==
+                                decodeUtf8(ByteArrayData.expect(key).bytes)
+                            )
+                        })
+                    }
+                    // loops over the Schema fields:
                     return Object.fromEntries(
                         schema.fieldTypes
-                            .map(({ name, type }) => {
+                            .map(({ name, encodingKey, type }) => {
                                 const i = expectSome(
-                                    entries.findIndex(
-                                        ([key, _]) =>
-                                            decodeUtf8(
-                                                ByteArrayData.expect(key).bytes
-                                            ) == name
-                                    )
+                                    findEncodedFieldIndex(encodingKey || name)
                                 )
 
                                 if (i == -1) {
+                                    // todo: ? allow Option[T] fields to be missing?
+                                    if (encodingKey) {
+                                        throw new Error(
+                                            `field '${name}' missing from MapData (must be encoded as '${encodingKey}')`
+                                        )
+                                    }
                                     throw new Error(
-                                        `field ${name} not found in MapData`
+                                        `field '${name}' missing from MapData`
                                     )
                                 }
 
-                                const pair = entries[i]
+                                const encodedDataPair = encodedEntries[i]
 
                                 return /** @type {const} */ ([
                                     i,
                                     name,
-                                    uplcToSchema(type, pair[1], config, defs)
+                                    uplcToSchemaWithDataPath(
+                                        type,
+                                        encodedDataPair[1],
+                                        {
+                                            ...context,
+                                            dataPath: `${dataPath}[mStruct].${name}`
+                                        }
+                                    )
                                 ])
                             })
                             .sort((a, b) => a[0] - b[0])
@@ -601,15 +714,21 @@ function uplcToSchema(schema, data, config, defs = {}) {
                 )
             }
 
+            const fieldCount = variantSchema.fieldTypes.length
             return {
                 [variantSchema.name]: Object.fromEntries(
                     fields.map((f, i) => [
                         variantSchema.fieldTypes[i].name,
-                        uplcToSchema(
+                        uplcToSchemaWithDataPath(
                             variantSchema.fieldTypes[i].type,
                             f,
-                            config,
-                            defs
+                            {
+                                ...context,
+                                dataPath: `${dataPath}[${schema.name}::${variantSchema.name}]`,
+                                // only skip extra ConstrData wrapper for the first field when this
+                                //   enum's shape indicates it is providing the CIP68 struct's wrapper
+                                isInEnum: fieldCount <= 3 && i == 0
+                            }
                         )
                     ])
                 )
@@ -617,14 +736,15 @@ function uplcToSchema(schema, data, config, defs = {}) {
         }
         case "variant": {
             defs[schema.id] = schema
-            const { fields } = ConstrData.expect(data)
+            throw new Error(`unused?`)
+            // const { fields } = ConstrData.expect(data)
 
-            return Object.fromEntries(
-                fields.map((field, i) => [
-                    schema.fieldTypes[i].name,
-                    uplcToSchema(schema.fieldTypes[i].type, field, config, defs)
-                ])
-            )
+            // return Object.fromEntries(
+            //     fields.map((field, i) => [
+            //         schema.fieldTypes[i].name,
+            //         uplcToSchema(schema.fieldTypes[i].type, field, config, defs)
+            //     ])
+            // )
         }
         default:
             throw new Error(`unhandled schema kind '${kind}'`)

--- a/src/cast/Cast.js
+++ b/src/cast/Cast.js
@@ -385,7 +385,7 @@ function schemaToUplc(schema, x, inputContextOnly) {
                 }
                 default:
                     throw new Error(
-                        `unhandled struct format '${schema.format}'`
+                        `unhandled struct format '${/** @type {any} */ (schema).format}'`
                     )
             }
         }
@@ -697,7 +697,7 @@ function uplcToSchema(schema, data, inputContextOnly) {
                 }
                 default:
                     throw new Error(
-                        `unhandled struct format '${schema.format}'`
+                        `unhandled struct format '${/** @type {any} */ (schema).format}'`
                     )
             }
         }

--- a/src/cast/Cast.test.js
+++ b/src/cast/Cast.test.js
@@ -158,11 +158,10 @@ describe("Cip68Struct serialization", () => {
             },
             {
                 name: "taggedFieldName",
-                encodingKey: "FNT",
+                key: "FNT",
                 type: {
                     kind: "internal",
                     name: "String"
-                    // encodingKey: "FNT"
                 }
             }
         ]
@@ -204,16 +203,32 @@ describe("Cip68Struct serialization", () => {
         ])
     ])
 
+    const missingField = new ConstrData(0, [
+        new MapData([
+            [new ByteArrayData(encodeUtf8("plainFieldName")), new IntData(1)],
+            [
+                new ByteArrayData(encodeUtf8("wrongFieldName")),
+                new ByteArrayData(encodeUtf8(greeting))
+            ]
+        ])
+    ])
+
     it("doesn't accept a struct with wrong encoding of field name when it expects a field-name tag", () => {
         throws(() => {
             cast.fromUplcData(wrongEncoding)
-        }, /decoding .*field 'taggedFieldName' missing.*must be encoded as 'FNT'/)
+        }, /decoding .*field 'taggedFieldName' encoded by name .*must be.* 'FNT'/)
+    })
+
+    it("doesn't accept a struct with missing field, when it expects a field-name tag", () => {
+        throws(() => {
+            cast.fromUplcData(missingField)
+        }, /decoding .*field 'taggedFieldName' missing .*must be encoded as 'FNT'/)
     })
 
     it("doesn't accept a struct with wrong encoding (e.g. a typo) of untagged field-name", () => {
         throws(() => {
             cast.fromUplcData(wrongPlainFieldName)
-        }, /decoding .* field 'plainFieldName' missing from MapData$/)
+        }, /decoding .* field 'plainFieldName' missing/)
     })
 
     it("parses a correctly encoded struct", () => {

--- a/src/cast/Cast.test.js
+++ b/src/cast/Cast.test.js
@@ -138,3 +138,121 @@ describe(Cast.name, () => {
         })
     })
 })
+
+describe("Cip68Struct serialization", () => {
+    /**
+     * @type {TypeSchema}
+     */
+    const schema = {
+        kind: "struct",
+        format: "map",
+        id: "has_field_tag",
+        name: "FieldTagged",
+        fieldTypes: [
+            {
+                name: "plainFieldName",
+                type: {
+                    kind: "internal",
+                    name: "Int"
+                }
+            },
+            {
+                name: "taggedFieldName",
+                encodingKey: "FNT",
+                type: {
+                    kind: "internal",
+                    name: "String"
+                    // encodingKey: "FNT"
+                }
+            }
+        ]
+    }
+
+    const cast = new Cast(schema, { isMainnet: false })
+    const greeting = "good day!"
+
+    const exampleData = new ConstrData(0, [
+        new MapData([
+            [new ByteArrayData(encodeUtf8("plainFieldName")), new IntData(1)],
+            [
+                new ByteArrayData(encodeUtf8("FNT")),
+                new ByteArrayData(encodeUtf8(greeting))
+            ]
+        ])
+    ])
+    const wrongPlainFieldName = new ConstrData(0, [
+        new MapData([
+            [
+                new ByteArrayData(encodeUtf8("wrongPlainFieldName")),
+                new IntData(1)
+            ],
+            [
+                new ByteArrayData(encodeUtf8("FNT")),
+                new ByteArrayData(encodeUtf8(greeting))
+            ]
+        ])
+    ])
+
+    const wrongEncoding = new ConstrData(0, [
+        new MapData([
+            [new ByteArrayData(encodeUtf8("plainFieldName")), new IntData(1)],
+            [
+                // has the definintion's field name, but should be the encoding key "FNT":
+                new ByteArrayData(encodeUtf8("taggedFieldName")),
+                new ByteArrayData(encodeUtf8(greeting))
+            ]
+        ])
+    ])
+
+    it("doesn't accept a struct with wrong encoding of field name when it expects a field-name tag", () => {
+        throws(() => {
+            cast.fromUplcData(wrongEncoding)
+        }, /decoding .*field 'taggedFieldName' missing.*must be encoded as 'FNT'/)
+    })
+
+    it("doesn't accept a struct with wrong encoding (e.g. a typo) of untagged field-name", () => {
+        throws(() => {
+            cast.fromUplcData(wrongPlainFieldName)
+        }, /decoding .* field 'plainFieldName' missing from MapData$/)
+    })
+
+    it("parses a correctly encoded struct", () => {
+        const actualObj = cast.fromUplcData(exampleData)
+
+        deepEqual(actualObj, {
+            plainFieldName: 1n,
+            taggedFieldName: greeting
+        })
+    })
+
+    it("doesn't generate UplcData based on field-name tag", () => {
+        throws(
+            () => {
+                cast.toUplcData({
+                    plainFieldName: 1,
+                    FNT: greeting
+                }).toSchemaJson()
+            },
+            new RegExp(
+                /field 'taggedFieldName' incorrectly specified as encoding-key 'FNT'/
+            )
+        )
+    })
+
+    it("includes input dataPath in thrown decoding errors (only if provided)", () => {
+        throws(() => {
+            cast.fromUplcData(wrongEncoding, "badThing")
+        }, /... at badThing/)
+
+        try {
+            cast.fromUplcData(wrongEncoding)
+            throw new Error("wrong encoding should have thrown an exception")
+        } catch (x) {
+            if (x.message.split("\n")[1]?.match(/\.\.\. at/)) {
+                throw new Error(
+                    `unexpected path in error message when input dataPath not provided\n - in thrown error message: \n\t${x.message}‹eom›`
+                )
+            }
+        }
+    })
+})

--- a/src/cast/Cast.test.js
+++ b/src/cast/Cast.test.js
@@ -80,7 +80,7 @@ describe(Cast.name, () => {
         })
     })
 
-    describe("Cip68Struct", () => {
+    describe("mStruct", () => {
         /**
          * @type {TypeSchema}
          */
@@ -109,11 +109,9 @@ describe(Cast.name, () => {
 
         const cast = new Cast(schema, { isMainnet: false })
 
-        const exampleData = new ConstrData(0, [
-            new MapData([
-                [new ByteArrayData(encodeUtf8("@b")), new IntData(1)],
-                [new ByteArrayData(encodeUtf8("@a")), new IntData(2)]
-            ])
+        const exampleData = new MapData([
+            [new ByteArrayData(encodeUtf8("@b")), new IntData(1)],
+            [new ByteArrayData(encodeUtf8("@a")), new IntData(2)]
         ])
 
         it("respects order when converting to uplc data", () => {
@@ -170,48 +168,44 @@ describe("Cip68Struct serialization", () => {
     const cast = new Cast(schema, { isMainnet: false })
     const greeting = "good day!"
 
-    const exampleData = new ConstrData(0, [
-        new MapData([
-            [new ByteArrayData(encodeUtf8("plainFieldName")), new IntData(1)],
-            [
-                new ByteArrayData(encodeUtf8("FNT")),
-                new ByteArrayData(encodeUtf8(greeting))
-            ]
-        ])
-    ])
-    const wrongPlainFieldName = new ConstrData(0, [
-        new MapData([
-            [
-                new ByteArrayData(encodeUtf8("wrongPlainFieldName")),
-                new IntData(1)
-            ],
-            [
-                new ByteArrayData(encodeUtf8("FNT")),
-                new ByteArrayData(encodeUtf8(greeting))
-            ]
-        ])
+    const exampleData = new MapData([
+        [new ByteArrayData(encodeUtf8("plainFieldName")), new IntData(1)],
+        [
+            new ByteArrayData(encodeUtf8("FNT")),
+            new ByteArrayData(encodeUtf8(greeting))
+        ]
     ])
 
-    const wrongEncoding = new ConstrData(0, [
-        new MapData([
-            [new ByteArrayData(encodeUtf8("plainFieldName")), new IntData(1)],
-            [
-                // has the definintion's field name, but should be the encoding key "FNT":
-                new ByteArrayData(encodeUtf8("taggedFieldName")),
-                new ByteArrayData(encodeUtf8(greeting))
-            ]
-        ])
+    const wrongPlainFieldName = new MapData([
+        [new ByteArrayData(encodeUtf8("wrongPlainFieldName")), new IntData(1)],
+        [
+            new ByteArrayData(encodeUtf8("FNT")),
+            new ByteArrayData(encodeUtf8(greeting))
+        ]
     ])
 
-    const missingField = new ConstrData(0, [
-        new MapData([
-            [new ByteArrayData(encodeUtf8("plainFieldName")), new IntData(1)],
-            [
-                new ByteArrayData(encodeUtf8("wrongFieldName")),
-                new ByteArrayData(encodeUtf8(greeting))
-            ]
-        ])
+    const wrongEncoding = new MapData([
+        [new ByteArrayData(encodeUtf8("plainFieldName")), new IntData(1)],
+        [
+            // has the definintion's field name, but should be the encoding key "FNT":
+            new ByteArrayData(encodeUtf8("taggedFieldName")),
+            new ByteArrayData(encodeUtf8(greeting))
+        ]
     ])
+
+    const missingField = new MapData([
+        [new ByteArrayData(encodeUtf8("plainFieldName")), new IntData(1)],
+        [
+            new ByteArrayData(encodeUtf8("wrongFieldName")),
+            new ByteArrayData(encodeUtf8(greeting))
+        ]
+    ])
+
+    it("doesn't accept a ConstrData wrapper around an mStruct", () => {
+        throws(() => {
+            cast.fromUplcData(new ConstrData(0, [exampleData]))
+        }, /expected MapData, got 0\{/)
+    })
 
     it("doesn't accept a struct with wrong encoding of field name when it expects a field-name tag", () => {
         throws(() => {

--- a/src/codegen/TypeSchema.js
+++ b/src/codegen/TypeSchema.js
@@ -7,10 +7,11 @@ const NONE = "null"
 /**
  * TODO: handle recursive data structures
  * @param {TypeSchema} schema
- * @param {string} [encodingKey] - optional field-name (encoding-key) for map-typed (Cip68) struct fields only
  * @returns {[string, string]} - the first entry is the strict canonical type, the second is the permissive type
  */
-export function genTypes(schema, encodingKey) {
+// XXX * @param {string} [encodingKey] - optional field-name (encoding-key) for map-typed struct fields only
+// XXX export function genTypes(schema, encodingKey) {
+export function genTypes(schema) {
     const kind = schema.kind
 
     switch (kind) {
@@ -127,9 +128,10 @@ export function genTypes(schema, encodingKey) {
         }
         case "struct": {
             const fieldTypes = schema.fieldTypes.map(
-                ({ name, encodingKey, type }) => ({
+                ({ name, type /* key - not used for type */ }) => ({
                     name: name,
-                    types: genTypes(type, encodingKey)
+                    // .. the field's definition name is always used, not the encoding key
+                    types: genTypes(type)
                 })
             )
 

--- a/src/codegen/TypeSchema.js
+++ b/src/codegen/TypeSchema.js
@@ -7,9 +7,10 @@ const NONE = "null"
 /**
  * TODO: handle recursive data structures
  * @param {TypeSchema} schema
+ * @param {string} [encodingKey] - optional field-name (encoding-key) for map-typed (Cip68) struct fields only
  * @returns {[string, string]} - the first entry is the strict canonical type, the second is the permissive type
  */
-export function genTypes(schema) {
+export function genTypes(schema, encodingKey) {
     const kind = schema.kind
 
     switch (kind) {
@@ -125,10 +126,12 @@ export function genTypes(schema) {
             return [`(${c}) | ${NONE}`, `(${p}) | null | undefined`]
         }
         case "struct": {
-            const fieldTypes = schema.fieldTypes.map(({ name, type }) => ({
-                name: name,
-                types: genTypes(type)
-            }))
+            const fieldTypes = schema.fieldTypes.map(
+                ({ name, encodingKey, type }) => ({
+                    name: name,
+                    types: genTypes(type, encodingKey)
+                })
+            )
 
             return [
                 `{${fieldTypes.map(({ name, types: [c, p] }) => `${name}: ${c}`).join(", ")}}`,
@@ -151,7 +154,7 @@ export function genTypes(schema) {
             ]
         }
         case "variant": {
-            // similar to structure
+            // similar to a list-typed struct (no encoding keys allowed)
             const fieldTypes = schema.fieldTypes.map(({ name, type }) => ({
                 name: name,
                 types: genTypes(type)

--- a/src/compiler/ops.test.js
+++ b/src/compiler/ops.test.js
@@ -132,3 +132,11 @@ describe(typeCheckScripts.name, () => {
         deepEqual(result.MapRec.data, inputData)
     })
 })
+
+// todo when we can import test/utils.js from the compiler more easily
+// describe("integration with UplcProgram", () => {
+//     // compileForRun
+//     it.todo("test: round-trips an fStruct", async () => {})
+//     it.todo("test: round-trips an mStruct", async () => {})
+//     it.todo("test: round-trips a CIP-68 struct", async () => {})
+// })


### PR DESCRIPTION
 - serialization keys are specified in .toJsonSchema()
 - cast.toUplcData() and fromUplcData() work using the defined field names for their interface, while encoding using the encodingKeys
 - uses type information provided by the compiler